### PR TITLE
Use builder-style API to set ListingTable definition

### DIFF
--- a/benchmarks/src/bin/h2o.rs
+++ b/benchmarks/src/bin/h2o.rs
@@ -83,7 +83,7 @@ async fn group_by(opt: &GroupBy) -> Result<()> {
         let listing_config = ListingTableConfig::new(ListingTableUrl::parse(path)?)
             .with_listing_options(ListingOptions::new(Arc::new(CsvFormat::default())))
             .with_schema(Arc::new(schema));
-        let csv = ListingTable::try_new(listing_config, None)?;
+        let csv = ListingTable::try_new(listing_config)?;
         let partition_size = num_cpus::get();
         let memtable =
             MemTable::load(Arc::new(csv), Some(partition_size), &ctx.state()).await?;

--- a/benchmarks/src/bin/tpch.rs
+++ b/benchmarks/src/bin/tpch.rs
@@ -429,7 +429,7 @@ fn get_table(
         .with_listing_options(options)
         .with_schema(schema);
 
-    Ok(Arc::new(ListingTable::try_new(config, None)?))
+    Ok(Arc::new(ListingTable::try_new(config)?))
 }
 
 fn get_schema(table: &str) -> Schema {

--- a/datafusion/core/benches/sort_limit_query_sql.rs
+++ b/datafusion/core/benches/sort_limit_query_sql.rs
@@ -74,7 +74,7 @@ fn create_context() -> Arc<Mutex<SessionContext>> {
         .with_listing_options(listing_options)
         .with_schema(schema);
 
-    let csv = async { ListingTable::try_new(config, None).unwrap() };
+    let csv = async { ListingTable::try_new(config).unwrap() };
 
     let rt = Runtime::new().unwrap();
 

--- a/datafusion/core/src/catalog/schema.rs
+++ b/datafusion/core/src/catalog/schema.rs
@@ -184,7 +184,7 @@ mod tests {
             .infer(&ctx.state())
             .await
             .unwrap();
-        let table = ListingTable::try_new(config, None).unwrap();
+        let table = ListingTable::try_new(config).unwrap();
 
         schema
             .register_table("alltypes_plain".to_string(), Arc::new(table))

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -560,7 +560,7 @@ impl SessionContext {
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(listing_options)
             .with_schema(resolved_schema);
-        let provider = ListingTable::try_new(config, None)?;
+        let provider = ListingTable::try_new(config)?;
         self.read_table(Arc::new(provider))
     }
 
@@ -586,7 +586,7 @@ impl SessionContext {
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(listing_options)
             .with_schema(resolved_schema);
-        let provider = ListingTable::try_new(config, None)?;
+        let provider = ListingTable::try_new(config)?;
 
         self.read_table(Arc::new(provider))
     }
@@ -620,7 +620,7 @@ impl SessionContext {
             .with_listing_options(listing_options)
             .with_schema(resolved_schema);
 
-        let provider = ListingTable::try_new(config, None)?;
+        let provider = ListingTable::try_new(config)?;
         self.read_table(Arc::new(provider))
     }
 
@@ -644,7 +644,7 @@ impl SessionContext {
             .with_listing_options(listing_options)
             .with_schema(resolved_schema);
 
-        let provider = ListingTable::try_new(config, None)?;
+        let provider = ListingTable::try_new(config)?;
         self.read_table(Arc::new(provider))
     }
 
@@ -676,7 +676,7 @@ impl SessionContext {
         let config = ListingTableConfig::new(table_path)
             .with_listing_options(options)
             .with_schema(resolved_schema);
-        let table = ListingTable::try_new(config, sql)?;
+        let table = ListingTable::try_new(config)?.with_definition(sql);
         self.register_table(name, Arc::new(table))?;
         Ok(())
     }

--- a/datafusion/core/tests/path_partition.rs
+++ b/datafusion/core/tests/path_partition.rs
@@ -441,7 +441,7 @@ fn register_partitioned_aggregate_csv(
     let config = ListingTableConfig::new(table_path)
         .with_listing_options(options)
         .with_schema(file_schema);
-    let table = ListingTable::try_new(config, None).unwrap();
+    let table = ListingTable::try_new(config).unwrap();
 
     ctx.register_table("t", Arc::new(table))
         .expect("registering listing table failed");
@@ -479,7 +479,7 @@ async fn register_partitioned_alltypes_parquet(
         .with_listing_options(options)
         .with_schema(file_schema);
 
-    let table = ListingTable::try_new(config, None).unwrap();
+    let table = ListingTable::try_new(config).unwrap();
 
     ctx.register_table("t", Arc::new(table))
         .expect("registering listing table failed");

--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -1261,7 +1261,7 @@ pub struct CreateExternalTable {
     pub table_partition_cols: Vec<String>,
     /// Option to not error if table already exists
     pub if_not_exists: bool,
-    /// SQL used to create the view, if available
+    /// SQL used to create the table, if available
     pub definition: Option<String>,
 }
 

--- a/datafusion/proto/src/logical_plan.rs
+++ b/datafusion/proto/src/logical_plan.rs
@@ -430,7 +430,7 @@ impl AsLogicalPlan for LogicalPlanNode {
                         .with_listing_options(options)
                         .with_schema(Arc::new(schema));
 
-                let provider = ListingTable::try_new(config, None)?;
+                let provider = ListingTable::try_new(config)?;
 
                 LogicalPlanBuilder::scan_with_filters(
                     &scan.table_name,


### PR DESCRIPTION
Proposed API change for https://github.com/apache/arrow-datafusion/pull/3279 to use a builder style API rather than a new argument to `ListingTable::try_new`